### PR TITLE
feat: add json code

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,10 +96,18 @@
     <div class="card">
       <div class="card-header">Python code</div>
       <div class="card-block">
-        <pre><code class="python source"></code></pre>
+        <pre><code class="python py-source"></code></pre>
       </div>
     </div>
   </div>
+  <div class="col-md-10 offset-md-1">
+    <div class="card">
+      <div class="card-header">JSON code</div>
+      <div class="card-block">
+        <pre><code class="json json-source"></code></pre>
+      </div>
+  </div>
+  
 </div>
   <script src='https://cdn.jsdelivr.net/npm/showdown@1.9.0/dist/showdown.min.js'></script>
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.1.0/jquery.min.js'></script>

--- a/js/index.js
+++ b/js/index.js
@@ -194,8 +194,10 @@ $(document).ready(function () {
     source += 'await ctx.send(embed=embed)\n';
 
     // code
-    $('.source').text(source);
-    hljs.highlightBlock($('.source')[0]);
+    $('.py-source').text(source);
+    hljs.highlightBlock($('.py-source')[0]);
+    $('.json-source').text(JSON.stringify(embed));
+    hljs.highlightBlock($('.json-source')[0]);
   }
 
   // run once on startup


### PR DESCRIPTION
I own a Discord bot and users can send their own embeds. They need a website to generate the JSON code easily. Should I redirect them to this website? If so, it would be nice to have a JSON code card. 